### PR TITLE
Add dst_io with tools for correction tables

### DIFF
--- a/antea/io/dst_io.py
+++ b/antea/io/dst_io.py
@@ -1,7 +1,9 @@
 import tables as tb
 import numpy  as np
 
-from invisible_cities.io. table_io    import make_table
+from invisible_cities.io  .table_io    import make_table
+from invisible_cities.io  .  dst_io    import load_dst
+from invisible_cities.reco.corrections import Correction
 
 
 class ZRfactors(tb.IsDescription):
@@ -39,3 +41,17 @@ def zr_correction_writer(hdf5_file, * ,
                      name         = table_name,
                      description  = "ZR corrections",
                      compression  = compression)
+
+
+def load_zr_corrections(filename, *,
+                        group = "Corrections",
+                        node  = "ZRcorrections",
+                        **kwargs):
+    dst  = load_dst(filename, group, node)
+    z, r = np.unique(dst.z.values), np.unique(dst.r.values)
+    f, u = dst.factor.values, dst.uncertainty.values
+
+    return Correction((z, r),
+                      f.reshape(z.size, r.size),
+                      u.reshape(z.size, r.size),
+                      **kwargs)

--- a/antea/io/dst_io.py
+++ b/antea/io/dst_io.py
@@ -1,0 +1,41 @@
+import tables as tb
+import numpy  as np
+
+from invisible_cities.io. table_io    import make_table
+
+
+class ZRfactors(tb.IsDescription):
+    z            = tb.Float32Col(pos=0)
+    r            = tb.Float32Col(pos=1)
+    factor       = tb.Float32Col(pos=2)
+    uncertainty  = tb.Float32Col(pos=3)
+    nevt         = tb. UInt32Col(pos=4)
+
+
+def zr_writer(hdf5_file, **kwargs):
+    zr_table = make_table(hdf5_file,
+                          fformat = ZRfactors,
+                          **kwargs)
+
+    def write_zr(zs, rs, fs, us, ns):
+        row = zr_table.row
+        for i, z in enumerate(zs):
+            for j, r in enumerate(rs):
+                row["z"]           = z
+                row["r"]           = r
+                row["factor"]      = fs[i,j]
+                row["uncertainty"] = us[i,j]
+                row["nevt"]        = ns[i,j]
+                row.append()
+    return write_zr
+
+
+def zr_correction_writer(hdf5_file, * ,
+                         group       = "Corrections",
+                         table_name  = "ZRcorrections",
+                         compression = 'ZLIB4'):
+    return zr_writer(hdf5_file,
+                     group        = group,
+                     name         = table_name,
+                     description  = "ZR corrections",
+                     compression  = compression)


### PR DESCRIPTION
With this PR a dst io file is added in order to have some tools for constructing ZR correction tables.
It contains the ZRfactors class with the parameters for the table, and the zr_writer and zr_correction_writer functions that write the table.