### PR TITLE
Add ChannelMatrix table to database

### DIFF
--- a/antea/database/download.py
+++ b/antea/database/download.py
@@ -7,7 +7,7 @@ import re
 from os import path
 
 
-tables = ['ChannelPositionP7R195Z140mm', 'ChannelGainP7R195Z140mm', 'ChannelMaskP7R195Z140mm', 'ChannelMappingP7R195Z140mm']
+tables = ['ChannelPositionP7R195Z140mm', 'ChannelGainP7R195Z140mm', 'ChannelMaskP7R195Z140mm', 'ChannelMappingP7R195Z140mm', 'ChannelMatrixP7R195Z140mm']
 
 
 def create_table_sqlite(cursorSqlite, cursorMySql, table):

--- a/antea/database/load_db.py
+++ b/antea/database/load_db.py
@@ -23,13 +23,15 @@ def DataSiPM(db_file, run_number=1e5, conf_label='P7R195Z140mm'):
 
     sql = '''select pos.SensorID, map.ElecID "ChannelID",
 case when msk.SensorID is NULL then 1 else 0 end "Active",
-X, Y, Z, Centroid "adc_to_pes", Sigma
+X, Y, Z, Centroid "adc_to_pes", Sigma, PhiNumber, ZNumber,
 from ChannelPosition{0} as pos INNER JOIN ChannelGain{0} as gain
 ON pos.SensorID = gain.SensorID INNER JOIN ChannelMapping{0} as map
-ON pos.SensorID = map.SensorID LEFT JOIN
+ON pos.SensorID = map.SensorID INNER JOIN ChannelMatrix{0} as mtrx
+ON pos.SensorID = mtrx.SensorID LEFT JOIN
 (select * from ChannelMask{0} where MinRun <= {1} and {1} <= MaxRun) as msk
 where pos.MinRun <= {1} and {1} <= pos.MaxRun
 and gain.MinRun <= {1} and {1} <= gain.MaxRun
+and mtrx.MinRun <= {1} and {1} <= mtrx.MaxRun
 order by pos.SensorID
 '''.format(conf_label, abs(run_number))
     data = pd.read_sql_query(sql, conn)
@@ -38,5 +40,5 @@ order by pos.SensorID
     ## Add default value to Sigma for runs without measurement
     if not data.Sigma.values.any():
         data.Sigma = 2.24
-        
+
     return data

--- a/antea/database/load_db.py
+++ b/antea/database/load_db.py
@@ -23,7 +23,7 @@ def DataSiPM(db_file, run_number=1e5, conf_label='P7R195Z140mm'):
 
     sql = '''select pos.SensorID, map.ElecID "ChannelID",
 case when msk.SensorID is NULL then 1 else 0 end "Active",
-X, Y, Z, Centroid "adc_to_pes", Sigma, PhiNumber, ZNumber,
+X, Y, Z, Centroid "adc_to_pes", Sigma, PhiNumber, ZNumber
 from ChannelPosition{0} as pos INNER JOIN ChannelGain{0} as gain
 ON pos.SensorID = gain.SensorID INNER JOIN ChannelMapping{0} as map
 ON pos.SensorID = map.SensorID INNER JOIN ChannelMatrix{0} as mtrx

--- a/antea/database/load_db_test.py
+++ b/antea/database/load_db_test.py
@@ -14,7 +14,7 @@ from . import load_db as DB
 def test_sipm_pd(db):
     """Check that we retrieve the correct number of SiPMs."""
     sipms = DB.DataSiPM(db.detector)
-    columns = ['SensorID', 'ChannelID', 'Active', 'X', 'Y', 'Z', 'adc_to_pes', 'Sigma']
+    columns = ['SensorID', 'ChannelID', 'Active', 'X', 'Y', 'Z', 'adc_to_pes', 'Sigma', 'PhiNumber', 'ZNumber']
     assert columns == list(sipms)
     assert sipms.shape[0] == db.nsipms
 

--- a/antea/database/localdb.PETALODB.sqlite3
+++ b/antea/database/localdb.PETALODB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:77ac450a4f109d3026cd787f4367fb937f273347ef745c45917c1ff646cb7d6d
-size 294912
+oid sha256:df2407b5bc599d460cb7294ff774840170afd526c1ff95ffb114373c3db8a34f
+size 364544


### PR DESCRIPTION
This PR adds a table to the database, which stores the row and column numbers of the SiPMs. Its is useful for the generation of the sensor response with look-up tables.