### PR TITLE
Test first interaction

### DIFF
--- a/antea/reco/reco_functions.py
+++ b/antea/reco/reco_functions.py
@@ -125,7 +125,7 @@ def initial_coord_first_daughter(particles: pd.DataFrame, mother_id: int) -> Tup
         init_vol = daughter.initial_volume
         return vtx_pos, min_t, init_vol
     else:
-        return [], -1, None
+        return [], float('inf'), None
 
 
 def part_first_hit(hits: pd.DataFrame, part_id: int) -> Tuple[Tuple[float, float, float], int]:
@@ -139,7 +139,7 @@ def part_first_hit(hits: pd.DataFrame, part_id: int) -> Tuple[Tuple[float, float
         part_pos = np.array([p_hit.x.values, p_hit.y.values, p_hit.z.values]).transpose()[0]
         return part_pos, t_min
     else:
-        return [], -1
+        return [], float('inf')
 
 
 def find_first_time_of_sensors(tof_response: pd.DataFrame, sns_ids: Sequence[int])-> Tuple[int, float]:
@@ -168,7 +168,7 @@ def reconstruct_coincidences(sns_response: pd.DataFrame, tof_response: pd.DataFr
                                                     Sequence[Tuple[float, float, float]],
                                                     Tuple[float, float, float],
                                                     Tuple[float, float, float],
-                                                    str, str, int, int, float, float]:
+                                                    int, int, float, float]:
     """
     Finds the SiPM with maximum charge. The set of sensors around it are labelled as 1.
     The sensors on the opposite hemisphere are labelled as 2.
@@ -197,7 +197,7 @@ def reconstruct_coincidences(sns_response: pd.DataFrame, tof_response: pd.DataFr
     sel1 = (tot_q1 > charge_range[0]) & (tot_q1 < charge_range[1])
     sel2 = (tot_q2 > charge_range[0]) & (tot_q2 < charge_range[1])
     if not sel1 or not sel2:
-        return [], [], [], [], None, None, None, None, None, None, None, None, None, None
+        return [], [], [], [], None, None, None, None, None, None, None, None
 
     ### select electrons, primary gammas daughters in ACTIVE
     sel_volume   = (particles.initial_volume == 'ACTIVE') & (particles.final_volume == 'ACTIVE')
@@ -210,10 +210,10 @@ def reconstruct_coincidences(sns_response: pd.DataFrame, tof_response: pd.DataFr
     vol1      , vol2       = [], []
     min_t1    , min_t2     = float('inf'), float('inf')
     if len(sel_all[sel_all.mother_id == 1]) > 0:
-        gamma_pos1, min_t1, vol1 = initial_coord_first_daughter(sel_all, 1)
+        gamma_pos1, min_t1, _ = initial_coord_first_daughter(sel_all, 1)
 
     if len(sel_all[sel_all.mother_id == 2]) > 0:
-        gamma_pos2, min_t2, vol2 = initial_coord_first_daughter(sel_all, 2)
+        gamma_pos2, min_t2, _ = initial_coord_first_daughter(sel_all, 2)
 
     ### Calculate the minimum time among the hits of a given primary gamma, if any.
     if len(hits[hits.particle_id == 1]) > 0:
@@ -221,18 +221,16 @@ def reconstruct_coincidences(sns_response: pd.DataFrame, tof_response: pd.DataFr
         if g_min_t1 < min_t1:
             min_t1     = g_min_t1
             gamma_pos1 = g_pos1
-            vol1 = 'ACTIVE'
 
     if len(hits[hits.particle_id == 2]) > 0:
         g_pos2, g_min_t2 = part_first_hit(hits, 2)
         if g_min_t2 < min_t2:
             min_t2     = g_min_t2
             gamma_pos2 = g_pos2
-            vol2 = 'ACTIVE'
 
     if not len(gamma_pos1) or not len(gamma_pos2):
         print("Cannot find two true gamma interactions for this event")
-        return [], [], [], [], None, None, None, None, None, None, None, None, None, None
+        return [], [], [], [], None, None, None, None, None, None, None, None
 
     true_pos1, true_pos2 = [], []
     true_t1 = true_t2 = -1
@@ -252,7 +250,7 @@ def reconstruct_coincidences(sns_response: pd.DataFrame, tof_response: pd.DataFr
     min1, min_tof1 = find_first_time_of_sensors(tof_response, sns1)
     min2, min_tof2 = find_first_time_of_sensors(tof_response, sns2)
 
-    return pos1, pos2, q1, q2, true_pos1, true_pos2, true_t1, true_t2, vol1, vol2, min1, min2, min_tof1, min_tof2
+    return pos1, pos2, q1, q2, true_pos1, true_pos2, true_t1, true_t2, min1, min2, min_tof1, min_tof2
 
 
 def select_coincidences(sns_response: pd.DataFrame, tof_response: pd.DataFrame,
@@ -264,7 +262,7 @@ def select_coincidences(sns_response: pd.DataFrame, tof_response: pd.DataFrame,
                                                     Tuple[float, float, float],
                                                     Tuple[float, float, float]]:
 
-    pos1, pos2, q1, q2, true_pos1, true_pos2, true_t1, true_t2, _, _, _, _, _, _ = reconstruct_coincidences(sns_response, tof_response, charge_range, DataSiPM_idx, particles, hits)
+    pos1, pos2, q1, q2, true_pos1, true_pos2, true_t1, true_t2, _, _, _, _ = reconstruct_coincidences(sns_response, tof_response, charge_range, DataSiPM_idx, particles, hits)
 
     return pos1, pos2, q1, q2, true_pos1, true_pos2, true_t1, true_t2
 
@@ -274,6 +272,6 @@ def find_first_times_of_coincidences(sns_response: pd.DataFrame, tof_response: p
                                      DataSiPM_idx: pd.DataFrame, particles: pd.DataFrame,
                                      hits: pd.DataFrame)-> Tuple[int, int, float, float]:
 
-    _, _, _, _, _, _, _, _, _, _, min1, min2, min_t1, min_t2 = reconstruct_coincidences(sns_response, tof_response, charge_range, DataSiPM_idx, particles, hits)
+    _, _, _, _, _, _, _, _, min1, min2, min_t1, min_t2 = reconstruct_coincidences(sns_response, tof_response, charge_range, DataSiPM_idx, particles, hits)
 
     return min1, min2, min_t1, min_t2

--- a/antea/reco/reco_functions_test.py
+++ b/antea/reco/reco_functions_test.py
@@ -372,5 +372,5 @@ def test_only_gamma_hits_interaction():
    assert len(pos1) != 0
    assert len(pos2) != 0
 
-   true_pos2 = np.array([181.8, -20.2, 69.2])
-   assert np.allclose(pos2, true_pos2)
+   ref_pos2 = np.array([181.8, -20.2, 69.2])
+   assert np.allclose(true_pos2, ref_pos2)

--- a/antea/reco/reco_functions_test.py
+++ b/antea/reco/reco_functions_test.py
@@ -122,7 +122,8 @@ l = st.lists(elements, min_size=2, max_size=1000)
 def test_divide_sipms_in_two_hemispheres(x, y, z, l):
     """
     This test checks that given a point, all the positions of a list of sensor
-    positions and charges are divided in two hemispheres according to that point.
+    positions and charges are divided in two hemispheres according
+    to that point.
     The way of testing it is by checking that the scalar product of the position
     of the sensors in the same hemisphere as the point, is positive.
     Every point in the center of coordinates is neglected in order to avoid
@@ -150,10 +151,10 @@ def test_divide_sipms_in_two_hemispheres(x, y, z, l):
 
 def test_assign_sipms_to_gammas(ANTEADATADIR):
     """
-    Checks that the function assign_sipms_to_gammas divides the SiPMs with charge
-    between the two back-to-back gammas, or to one of the two if the other one hasn't
-    interacted by calculating the scalar product between the sensors and the closest
-    sensor to the interaction point.
+    Checks that the function assign_sipms_to_gammas divides the SiPMs
+    with charge between the two back-to-back gammas, or to one of the two
+    if the other one hasn't interacted by calculating the scalar product
+    between the sensors and the closest sensor to the interaction point.
     """
     PATH_IN      = os.path.join(ANTEADATADIR, 'ring_test_1000ev.h5')
     DataSiPM     = db.DataSiPM('petalo', 0)
@@ -203,7 +204,8 @@ part_id = st.integers(min_value=1, max_value=1000)
 @given(part_id)
 def test_initial_coord_first_daughter(ANTEADATADIR, part_id):
     """
-    This test checks that the function initial_coord_first_daughter returns the position,
+    This test checks that the function initial_coord_first_daughter returns
+    the position,
     time and volume of the initial vertex of the first daughter of a particle.
     """
     PATH_IN   = os.path.join(ANTEADATADIR, 'ring_test.h5')
@@ -252,9 +254,9 @@ def test_part_first_hit(ANTEADATADIR, part_id):
 
 def test_find_first_time_of_sensors(ANTEADATADIR):
     """
-    Checks that the function find_first_time_of_sensors returns the sensors id and
-    the time of the first photoelectron detected among all sensors per event.
-    The sensor id must be positive.
+    Checks that the function find_first_time_of_sensors returns the sensors id
+    and the time of the first photoelectron detected among all sensors
+    per event. The sensor id must be positive.
     """
     PATH_IN = os.path.join(ANTEADATADIR, 'ring_test.h5')
     tof_response = load_mcTOFsns_response(PATH_IN)
@@ -274,9 +276,9 @@ def test_find_first_time_of_sensors(ANTEADATADIR):
 
 def test_select_coincidences(ANTEADATADIR):
     """
-    This test checks that the function reconstruct_coincidences returns the position
-    of the true events and the position and charge of the sensors that detected
-    charge only when coincidences are produced.
+    This test checks that the function reconstruct_coincidences returns the
+    position of the true events and the position and charge of the sensors
+    that detected charge only when coincidences are produced.
     """
     PATH_IN      = os.path.join(ANTEADATADIR, 'ring_test_1000ev.h5')
     DataSiPM     = db.DataSiPM('petalo', 0)
@@ -305,7 +307,7 @@ def test_select_coincidences(ANTEADATADIR):
         if len(sns) == 0: continue
         tof = tof_response[tof_response.event_id == evt]
 
-        pos1, pos2, q1, q2, true_pos1, true_pos2, _, _ = rf.select_coincidences(sns, tof, charge_range, DataSiPM_idx, evt_parts, evt_hits)
+        pos1, pos2, q1, q2, true_pos1, true_pos2, true_t1, true_t2 = rf.select_coincidences(sns, tof, charge_range, DataSiPM_idx, evt_parts, evt_hits)
 
         if len(true_pos) == 2:
             scalar_prod1 = np.array([np.dot(true_pos1, p1) for p1 in pos1])
@@ -328,6 +330,8 @@ def test_select_coincidences(ANTEADATADIR):
             true_pos_cyl = rf.from_cartesian_to_cyl(np.array([true_pos1, true_pos2]))
             true_r       = np.array([i[0] for i in true_pos_cyl])
             assert (true_r > radius_range[0]).all() and (true_r < radius_range[1]).all()
+            assert true_t1 > 0
+            assert true_t2 > 0
 
         else:
             assert not true_pos1 and not true_pos2
@@ -337,31 +341,40 @@ def test_select_coincidences(ANTEADATADIR):
 
 def test_only_gamma_hits_interaction():
    """
-    This test uses an event where one primary gamma interacts in the cryostat first, then creates an
-    electron in the ACTIVE volume, while the other primary gamma interacts directly in the active volume.
-    and deposits only true energy hits, without creating an electron. This test is supposed to fail
-    if the true position of the second gamma is miscalculated.
+    This test uses an event where one primary gamma interacts in the cryostat
+    first, then creates an electron in the ACTIVE volume, while the other
+    primary gamma interacts directly in the active volume and deposits
+    only true energy hits, without creating an electron.
+    This test is supposed to fail if the true position of the second gamma
+    is miscalculated.
     """
 
    data = {'event_id': [0, 0, 0, 0], 'particle_id': [1, 2, 3, 4],
            'name': ['gamma', 'gamma', 'e-', 'e-'], 'primary': [1, 1, 0, 0],
            'mother_id': [0, 0, 1, 1], 'initial_x': [0.0, 0.0, -162.5, -181.8],
-           'initial_y': [0.0, 0.0, 6.4, 20.2], 'initial_z': [0.0, 0.0, -46.7, -69.2],
-           'initial_t': [0.0, 0.0, 0.61, 0.63], 'final_x': [-181.8, 181.8, -161.5, -182.8],
-           'final_y': [20.2, -20.2, 6.5, 21.2], 'final_z': [-69.2, 69.2, -45.7, -70.2],
+           'initial_y': [0.0, 0.0, 6.4, 20.2],
+           'initial_z': [0.0, 0.0, -46.7, -69.2],
+           'initial_t': [0.0, 0.0, 0.61, 0.63],
+           'final_x': [-181.8, 181.8, -161.5, -182.8],
+           'final_y': [20.2, -20.2, 6.5, 21.2],
+           'final_z': [-69.2, 69.2, -45.7, -70.2],
            'final_t': [0.61, 0.67, 0.62, 0.64],
            'initial_volume': ['PHANTOM', 'PHANTOM', 'CRYOSTAT', 'ACTIVE'],
            'final_volume': ['ACTIVE', 'ACTIVE', 'CRYOSTAT', 'ACTIVE']}
    particles = pd.DataFrame(data)
 
-   hits_data = {'event_id': [0, 0], 'x': [-181.8, 181.8], 'y': [20.2, -20.2], 'z': [-69.2, 69.2], 'time': [0.63, 0.67], 'energy': [1, 1], 'particle_id': [4, 2]}
+   hits_data = {'event_id': [0, 0], 'x': [-181.8, 181.8], 'y': [20.2, -20.2],
+                'z': [-69.2, 69.2], 'time': [0.63, 0.67], 'energy': [1, 1],
+                'particle_id': [4, 2]}
    hits = pd.DataFrame(hits_data)
 
-   sns_data = {'event_id': [0, 0], 'sensor_id': [2021, 3503], 'time_bin': [0, 0], 'charge': [1100, 1200]}
+   sns_data = {'event_id': [0, 0], 'sensor_id': [2021, 3503],
+               'time_bin': [0, 0], 'charge': [1100, 1200]}
    sns = pd.DataFrame(sns_data)
 
-   tof_data = {'event_id': [0, 0], 'sensor_id': [-2021, -3503], 'time_bin': [151, 200],
-                'charge': [1100, 1200]}
+   tof_data = {'event_id': [0, 0], 'sensor_id': [-2021, -3503],
+               'time_bin': [151, 200],
+               'charge': [1100, 1200]}
    tof = pd.DataFrame(tof_data)
 
    DataSiPM     = db.DataSiPM('petalo', 0)


### PR DESCRIPTION
This PR fixes a small bug, which shouldn't be affecting our current analyses. In the case where a primary gamma doesn't have electron daughters in the ACTIVE volume, but does deposit some energy through true hits associated to itself, the `reconstruct_coincidences` function rejected the interaction. This is not an expected behaviour, therefore this PR fixes it. 
Also, since the `reconstruct_coincidences` function always returns the position of the first interaction of gammas in the ACTIVE volume, I've eliminated the returning of the volumes.
Finally, two time variables used to find the minimum time were initialized to `-1`, which was dangerous; I've changed them to `float('inf')`.