### PR TITLE
Fix type for sensor ids

### DIFF
--- a/antea/core/exceptions.py
+++ b/antea/core/exceptions.py
@@ -1,0 +1,12 @@
+"""
+Define ANTEA-specific exceptions
+"""
+
+class ANTEAException(Exception):
+    """ Base class for ANTEA exceptions hierarchy """
+
+class NoInputFiles(ANTEAException):
+    """ Input files list is not defined """
+
+class WaveformEmptyTable(ANTEAException):
+    pass

--- a/antea/reco/reco_functions.py
+++ b/antea/reco/reco_functions.py
@@ -3,6 +3,8 @@ import pandas as pd
 
 from . mctrue_functions import find_hits_of_given_particles
 
+from antea.core.exceptions import WaveformEmptyTable
+
 from typing import Sequence, Tuple
 
 
@@ -193,6 +195,8 @@ def find_first_time_of_sensors(tof_response: pd.DataFrame,
     min_t  = tof.time_bin.min()
     min_df = tof[tof.time_bin == min_t]
 
+    if len(min_df)==0:
+        raise WaveformEmptyTable("Tof dataframe is empty")
     if len(min_df)>1:
         min_id = min_df[min_df.sensor_id == min_df.sensor_id.min()].sensor_id.values[0]
     else:

--- a/antea/reco/reco_functions.py
+++ b/antea/reco/reco_functions.py
@@ -112,7 +112,7 @@ def assign_sipms_to_gammas(sns_response: pd.DataFrame,
     if 'SensorID' in DataSiPM_idx.columns:
         DataSiPM_idx = DataSiPM_idx.set_index('SensorID')
     sipms           = DataSiPM_idx.loc[sns_response.sensor_id]
-    sns_ids         = sipms.index.values
+    sns_ids         = sipms.index.astype('int64').values
     sns_closest_pos = [np.array([find_closest_sipm(pos, sipms).X,
                                  find_closest_sipm(pos, sipms).Y,
                                  find_closest_sipm(pos, sipms).Z])
@@ -307,7 +307,7 @@ def reconstruct_coincidences(sns_response: pd.DataFrame,
     max_pos  = np.array([max_sipm.X.values, max_sipm.Y.values, max_sipm.Z.values]).transpose()[0]
 
     sipms         = DataSiPM_idx.loc[sns_response.sensor_id]
-    sns_ids       = sipms.index.values
+    sns_ids       = sipms.index.astype('int64').values
     sns_positions = np.array([sipms.X.values, sipms.Y.values, sipms.Z.values]).transpose()
     sns_charges   = sns_response.charge
 
@@ -322,10 +322,8 @@ def reconstruct_coincidences(sns_response: pd.DataFrame,
         return [], [], [], [], None, None, None, None, None, None, None, None
 
     ### TOF
-    sns1 = -np.array(sns1)
-    sns2 = -np.array(sns2)
-    min1, min_tof1 = find_first_time_of_sensors(tof_response, sns1)
-    min2, min_tof2 = find_first_time_of_sensors(tof_response, sns2)
+    min1, min_tof1 = find_first_time_of_sensors(tof_response, -sns1)
+    min2, min_tof2 = find_first_time_of_sensors(tof_response, -sns2)
 
     true_pos1, true_pos2, true_t1, true_t2, _, _ = find_first_interactions_in_active(particles, hits)
 

--- a/antea/reco/reco_functions.py
+++ b/antea/reco/reco_functions.py
@@ -192,11 +192,12 @@ def find_first_time_of_sensors(tof_response: pd.DataFrame,
     are returned.
     """
     tof = tof_response[tof_response.sensor_id.isin(sns_ids)]
+    if tof.empty:
+        raise WaveformEmptyTable("Tof dataframe is empty")
+
     min_t  = tof.time_bin.min()
     min_df = tof[tof.time_bin == min_t]
 
-    if len(min_df)==0:
-        raise WaveformEmptyTable("Tof dataframe is empty")
     if len(min_df)>1:
         min_id = min_df[min_df.sensor_id == min_df.sensor_id.min()].sensor_id.values[0]
     else:

--- a/antea/reco/reco_functions.py
+++ b/antea/reco/reco_functions.py
@@ -83,13 +83,13 @@ def divide_sipms_in_two_hemispheres(sns_ids: Sequence[int],
         if scalar_prod > 0.:
             q1  .append(charge)
             pos1.append(sns_pos)
-            id1.append(sns_id)
+            id1 .append(sns_id)
         else:
             q2  .append(charge)
             pos2.append(sns_pos)
-            id2.append(sns_id)
+            id2 .append(sns_id)
 
-    return id1, id2, pos1, pos2, np.array(q1), np.array(q2)
+    return np.array(id1), np.array(id2), np.array(pos1), np.array(pos2), np.array(q1), np.array(q2)
 
 
 

--- a/antea/reco/reco_functions_test.py
+++ b/antea/reco/reco_functions_test.py
@@ -6,14 +6,16 @@ import hypothesis.strategies as st
 
 from hypothesis  import given
 from hypothesis  import assume
+from pytest      import raises
 from .           import reco_functions   as rf
 from .           import mctrue_functions as mcf
 from .. database import load_db          as db
 
-from .. io.mc_io import load_mchits
-from .. io.mc_io import load_mcparticles
-from .. io.mc_io import load_mcsns_response
-from .. io.mc_io import load_mcTOFsns_response
+from .. io  .mc_io      import load_mchits
+from .. io  .mc_io      import load_mcparticles
+from .. io  .mc_io      import load_mcsns_response
+from .. io  .mc_io      import load_mcTOFsns_response
+from .. core.exceptions import WaveformEmptyTable
 
 
 DataSiPM     = db.DataSiPM('petalo', 0)
@@ -272,6 +274,21 @@ def test_find_first_time_of_sensors(ANTEADATADIR):
         for t in times:
             assert rf.lower_or_equal(result[1], t)
             assert rf.lower_or_equal(time_from_id, t)
+
+
+l = st.lists(st.integers(min_value=-10000, max_value=-1000), min_size=1, max_size=5)
+
+@given(l)
+def test_find_first_time_of_sensors_raises_WaveformEmptyTable(l):
+    """
+    Tests that function find_first_time_of_sensors raises an exception
+    if input tof is empty.
+    """
+    keys  = np.array(['event_id', 'sensor_id', 'time_bin', 'charge'])
+    wf_df = pd.DataFrame({}, columns = keys)
+
+    with raises(WaveformEmptyTable):
+        rf.find_first_time_of_sensors(wf_df, l)
 
 
 def test_change_unsigned_type_sipm(ANTEADATADIR):


### PR DESCRIPTION
This PR fixes the object type for the sensor ids when taken from the database because pandas assumes they are unsigned integers.

Also I have changed in the divide_sipms_in_two_hemispheres function the returned objects to be numpy arrays.

And last, I have added a condition in function find_first_time_of_sensors for the case the dataframe is empty, before it was not considered.