### PR TITLE
Fix tests

### DIFF
--- a/antea/elec/tof_functions_test.py
+++ b/antea/elec/tof_functions_test.py
@@ -3,10 +3,9 @@ import numpy                 as np
 import pandas                as pd
 import hypothesis.strategies as st
 
-from hypothesis  import given
-
-import tof_functions as tf
+from hypothesis     import given
 from antea.io.mc_io import load_mcTOFsns_response
+from antea.elec     import tof_functions   as tf
 
 
 a = st.floats(min_value=1, max_value=100000)


### PR DESCRIPTION
This PR adds the `__init__` file needed for the tests files in the elec directory, changes how is imported `tof_functions` in `tof_functions_test`, and fixes an error in the function `spe_dist`. This change in the function forced to split the corresponding test in two and to fix the `convolve_tof` test.