### PR TITLE
Fix test to find closest SiPM to a given point

### DIFF
--- a/antea/reco/reco_functions_test.py
+++ b/antea/reco/reco_functions_test.py
@@ -86,19 +86,17 @@ def test_find_SiPMs_over_threshold(ANTEADATADIR):
     assert len(df_over_thr) == len(sns_response) - len(df_below_thr)
 
 
-sipm_id = st.integers(0, len(DataSiPM))
+sipm_id = st.integers(0, len(DataSiPM)-1)
 @given(x, y, z, sipm_id)
 def test_find_closest_sipm(x, y, z, sipm_id):
     """
     Checks that the function find_closest_sipm returns the position of the
     closest SiPM to a given point, and the distance between them is a positive
     quantity.
-    If the point is in the center of the coordinate system or far from the
-    sensors, the function takes more than one sipm because many of them are
-    at the same distance, so a range for the radius is imposed.
     """
-    r = np.sqrt(x**2+y**2)
-    if r < 1: return
+
+    if x == 0. and y == 0. and z == 0.:
+       return
 
     point        = np.array([x, y, z])
     closest_sipm = rf.find_closest_sipm(point, DataSiPM_idx)

--- a/antea/reco/reco_functions_test.py
+++ b/antea/reco/reco_functions_test.py
@@ -5,6 +5,7 @@ import pandas                as pd
 import hypothesis.strategies as st
 
 from hypothesis  import given
+from hypothesis  import assume
 from .           import reco_functions   as rf
 from .           import mctrue_functions as mcf
 from .. database import load_db          as db
@@ -95,8 +96,9 @@ def test_find_closest_sipm(x, y, z, sipm_id):
     quantity.
     """
 
-    if x == 0. and y == 0. and z == 0.:
-       return
+    assume(x != 0)
+    assume(y != 0)
+    assume(z != 0)
 
     point        = np.array([x, y, z])
     closest_sipm = rf.find_closest_sipm(point, DataSiPM_idx)


### PR DESCRIPTION
This PR fixes a test that used to fail when a number which is higher than the maximum SiPM ID was chosen by `hypothesis` as the ID of the sensor to compare with.
Also, it was observed that the case `x == y == z == 0` failed because of the precision in the database positions of the SiPMs. Since no PET rings of zero radius are realistic, an assumption to exclude this specific case has been added.