### PR TITLE
Fix tof test

### DIFF
--- a/antea/elec/tof_functions.py
+++ b/antea/elec/tof_functions.py
@@ -4,12 +4,12 @@ import pandas as pd
 from typing import Sequence, Tuple
 
 
-def spe_dist(time: Sequence[float], tau_sipm=[100, 15000]) -> Sequence[float]:
+def spe_dist(time: Sequence[float]) -> Sequence[float]:
     """
     Double exponential decay for the sipm response. Returns a normalized array.
     """
-    alfa         = 1.0/tau_sipm[1]
-    beta         = 1.0/tau_sipm[0]
+    alfa         = 1.0/15000
+    beta         = 1.0/100
     t_p          = np.log(beta/alfa)/(beta-alfa)
     K            = (beta)*np.exp(alfa*t_p)/(beta-alfa)
     spe_response = K*(np.exp(-alfa*time)-np.exp(-beta*time))

--- a/antea/elec/tof_functions.py
+++ b/antea/elec/tof_functions.py
@@ -4,14 +4,12 @@ import pandas as pd
 from typing import Sequence, Tuple
 
 
-def spe_dist(tau_sipm: Tuple[float, float], time: Sequence[float]) -> Sequence[float]:
+def spe_dist(time: Sequence[float], tau_sipm=[100, 15000]) -> Sequence[float]:
     """
     Double exponential decay for the sipm response. Returns a normalized array.
     """
     alfa         = 1.0/tau_sipm[1]
     beta         = 1.0/tau_sipm[0]
-    if np.isclose(alfa, beta, rtol=1e-2):
-        return np.zeros(len(time))
     t_p          = np.log(beta/alfa)/(beta-alfa)
     K            = (beta)*np.exp(alfa*t_p)/(beta-alfa)
     spe_response = K*(np.exp(-alfa*time)-np.exp(-beta*time))

--- a/antea/elec/tof_functions_test.py
+++ b/antea/elec/tof_functions_test.py
@@ -23,15 +23,14 @@ def test_spe_dist(l):
     assert np.isclose(np.sum(exp_dist), 1)
 
 
-t = st.tuples(st.floats(min_value=1, max_value=1000), st.floats(min_value=2, max_value=1000))
 s = st.lists(st.integers(min_value=1, max_value=10000), min_size=2, max_size=1000)
 
-@given(t, l, s)
-def test_convolve_tof(t, l, s):
+@given(l, s)
+def test_convolve_tof(l, s):
     """
     Check that the function convolve_tof returns an array with the adequate length, and, in case it is
     """
-    spe_response = tf.spe_dist(t, np.unique(np.array(l)))
+    spe_response = tf.spe_dist(np.unique(np.array(l)))
     conv_res     = tf.convolve_tof(spe_response, np.array(s))
     assert len(conv_res) == len(spe_response) + len(s) - 1
     if np.count_nonzero(spe_response):

--- a/antea/elec/tof_functions_test.py
+++ b/antea/elec/tof_functions_test.py
@@ -8,27 +8,19 @@ from antea.io.mc_io import load_mcTOFsns_response
 from antea.elec     import tof_functions   as tf
 
 
-a = st.floats(min_value=1, max_value=100000)
-b = st.floats(min_value=2, max_value=100000)
 l = st.lists(st.integers(min_value=1, max_value=10000), min_size=2, max_size=1000)
 
-@given(a, b, l)
-def test_spe_dist(a, b, l):
+@given(l)
+def test_spe_dist(l):
     """
-    This test checks that the function spe_dist returns an array with the distribution value for each time and in case the distribution contains only zeros, it ensures that it returns a fully zeros array, avoiding the normalization.
+    This test checks that the function spe_dist returns an array with the distribution value for each time.
     """
     l        = np.array(l)
-    exp_dist = tf.spe_dist((a, b), np.unique(l))
-    count_a  = np.count_nonzero(np.exp(-(1/a)*l))
-    count_b  = np.count_nonzero(np.exp(-(1/b)*l))
+    exp_dist = tf.spe_dist(np.unique(l))
 
-    if np.isclose(1/a, 1/b, rtol=1e-2) or (not count_a and not count_b):
-        assert np.count_nonzero(exp_dist) == 0
-        assert np.isclose(np.sum(exp_dist), 0)
-    else:
-        assert len(exp_dist) == len(np.unique(l))
-        assert (exp_dist >= 0.).all()
-        assert np.isclose(np.sum(exp_dist), 1)
+    assert len(exp_dist) == len(np.unique(l))
+    assert (exp_dist >= 0.).all()
+    assert np.isclose(np.sum(exp_dist), 1)
 
 
 t = st.tuples(st.floats(min_value=1, max_value=1000), st.floats(min_value=2, max_value=1000))


### PR DESCRIPTION
This PR fixes a test that was failing in tof_functions. In the function spe_dist the values for tau_sipm were fixed simplifying it and thus the test. Test corresponding to convolve_tof function in the call to spe_dist function has been changed too.