### PR TITLE
Change of return values in `reconstruct_coincidences` function

### DIFF
--- a/antea/reco/reco_functions.py
+++ b/antea/reco/reco_functions.py
@@ -356,36 +356,11 @@ def reconstruct_coincidences(sns_response: pd.DataFrame,
     return int_pos1, int_pos2, int_q1, int_q2, true_pos1, true_pos2, true_t1, true_t2, sns1, sns2
 
 
-def select_coincidences(sns_response: pd.DataFrame, tof_response: pd.DataFrame,
-                        charge_range: Tuple[float, float],
-                        DataSiPM_idx: pd.DataFrame, particles: pd.DataFrame,
-                        hits: pd.DataFrame)-> Tuple[Sequence[Tuple[float, float, float]],
-                                                    Sequence[Tuple[float, float, float]],
-                                                    Sequence[float], Sequence[float],
-                                                    Tuple[float, float, float],
-                                                    Tuple[float, float, float],
-                                                    float, float]:
-    """
-    This function returns positions and charges (true and reconstructed)
-    of two sets of SiPMs, each one corresponding to 1 gamma interaction.
-    DataSiPM_idx is assumed to be indexed on the sensor ids.
-    """
-    pos1, pos2, q1, q2, true_pos1, true_pos2, true_t1, true_t2, _, _, _, _ = reconstruct_coincidences(sns_response, tof_response, charge_range, DataSiPM_idx, particles, hits)
+def find_timestamps(tof_response: pd.DataFrame,
+                    sns1: Sequence[int], sns2: Sequence[int])-> Tuple[int, int,
+                                                                      int, int]:
 
-    return pos1, pos2, q1, q2, true_pos1, true_pos2, true_t1, true_t2
+    min1, time1 = find_first_time_of_sensors(tof_response, -sns1)
+    min2, time2 = find_first_time_of_sensors(tof_response, -sns2)
 
-
-def find_first_times_of_coincidences(sns_response: pd.DataFrame,
-                                     tof_response: pd.DataFrame,
-                                     charge_range: Tuple[float, float],
-                                     DataSiPM_idx: pd.DataFrame,
-                                     particles: pd.DataFrame,
-                                     hits: pd.DataFrame)-> Tuple[int, int, int, int]:
-    """
-    This function returns the IDs and times of the SiPMs that detect
-    the first photoelectrons, given the two sets of sensor IDs corresponding to the two interactions.
-    DataSiPM_idx is assumed to be indexed on the sensor ids.
-    """
-    _, _, _, _, _, _, _, _, min1, min2, min_t1, min_t2 = reconstruct_coincidences(sns_response, tof_response, charge_range, DataSiPM_idx, particles, hits)
-
-    return min1, min2, min_t1, min_t2
+    return min1, min2, time1, time2

--- a/antea/reco/reco_functions.py
+++ b/antea/reco/reco_functions.py
@@ -339,26 +339,18 @@ def reconstruct_coincidences(sns_response: pd.DataFrame,
         int_pos2 = pos2
         int_q1   = q1
         int_q2   = q2
-        int_min1 = min1
-        int_min2 = min2
-        int_tof1 = min_tof1
-        int_tof2 = min_tof2
     else:
         int_pos1 = pos2
         int_pos2 = pos1
         int_q1   = q2
         int_q2   = q1
-        int_min1 = min2
-        int_min2 = min1
-        int_tof1 = min_tof2
-        int_tof2 = min_tof1
 
     return int_pos1, int_pos2, int_q1, int_q2, true_pos1, true_pos2, true_t1, true_t2, sns1, sns2
 
 
-def find_timestamps(tof_response: pd.DataFrame,
-                    sns1: Sequence[int], sns2: Sequence[int])-> Tuple[int, int,
-                                                                      int, int]:
+def find_coincidence_timestamps(tof_response: pd.DataFrame,
+                                sns1: Sequence[int],
+                                sns2: Sequence[int])-> Tuple[int, int, int, int]:
 
     min1, time1 = find_first_time_of_sensors(tof_response, -sns1)
     min2, time2 = find_first_time_of_sensors(tof_response, -sns2)

--- a/antea/reco/reco_functions.py
+++ b/antea/reco/reco_functions.py
@@ -329,13 +329,13 @@ def reconstruct_coincidences(sns_response: pd.DataFrame,
     sel1 = (tot_q1 > charge_range[0]) & (tot_q1 < charge_range[1])
     sel2 = (tot_q2 > charge_range[0]) & (tot_q2 < charge_range[1])
     if not sel1 or not sel2:
-        return [], [], [], [], None, None, None, None, None, None, None, None
+        return [], [], [], [], None, None, None, None, [], []
 
     true_pos1, true_pos2, true_t1, true_t2, _, _ = find_first_interactions_in_active(particles, hits)
 
     if not len(true_pos1) or not len(true_pos2):
         print("Cannot find two true gamma interactions for this event")
-        return [], [], [], [], None, None, None, None, None, None, None, None
+        return [], [], [], [], None, None, None, None, [], []
 
     scalar_prod = true_pos1.dot(max_pos)
     if scalar_prod > 0:

--- a/antea/reco/reco_functions.py
+++ b/antea/reco/reco_functions.py
@@ -283,7 +283,6 @@ def find_first_interactions_in_active(particles: pd.DataFrame,
 
 
 def reconstruct_coincidences(sns_response: pd.DataFrame,
-                             tof_response: pd.DataFrame,
                              charge_range: Tuple[float, float],
                              DataSiPM_idx: pd.DataFrame,
                              particles: pd.DataFrame,

--- a/antea/reco/reco_functions.py
+++ b/antea/reco/reco_functions.py
@@ -208,7 +208,11 @@ def find_first_time_of_sensors(tof_response: pd.DataFrame,
 
 def find_hit_distances_from_true_pos(hits: pd.DataFrame,
                                      true_pos: Tuple[float, float, float]) -> Sequence[float]:
-    positions        = np.array([hits.x, hits.y, hits.z]).transpose()
+    """
+    Calculates the distances of all the hits in the same hemisphere of a given point,
+    from the given point.
+    """
+    positions       = np.array([hits.x, hits.y, hits.z]).transpose()
     scalar_products = positions.dot(true_pos)
     int_hits = hits[scalar_products >= 0]
     pos_hits = np.array([int_hits.x.values, int_hits.y.values, int_hits.z.values]).transpose()
@@ -220,10 +224,10 @@ def find_hit_distances_from_true_pos(hits: pd.DataFrame,
 
 def find_first_interactions_in_active(particles: pd.DataFrame,
                                       hits: pd.DataFrame,
-                                      photo_range: float = 1.) -> Tuple[Tuple[float, float, float],
-                                                                        Tuple[float, float, float],
-                                                                        float, float,
-                                                                        bool, bool]:
+                                      photo_range: float = 1.)-> Tuple[Tuple[float, float, float],
+                                                                       Tuple[float, float, float],
+                                                                       float, float,
+                                                                       bool, bool]:
     """
     Looks for the first interaction of primary gammas in the active volume.
     """
@@ -351,7 +355,10 @@ def reconstruct_coincidences(sns_response: pd.DataFrame,
 def find_coincidence_timestamps(tof_response: pd.DataFrame,
                                 sns1: Sequence[int],
                                 sns2: Sequence[int])-> Tuple[int, int, int, int]:
-
+    """
+    Finds the first time and sensor of each one of two sets of sensors,
+    given a sensor response dataframe.
+    """
     min1, time1 = find_first_time_of_sensors(tof_response, -sns1)
     min2, time2 = find_first_time_of_sensors(tof_response, -sns2)
 

--- a/antea/reco/reco_functions.py
+++ b/antea/reco/reco_functions.py
@@ -283,12 +283,13 @@ def reconstruct_coincidences(sns_response: pd.DataFrame,
                              charge_range: Tuple[float, float],
                              DataSiPM_idx: pd.DataFrame,
                              particles: pd.DataFrame,
-                             hits: pd.DataFrame) -> Tuple[Sequence[Tuple[float, float, float]],
-                                                    Sequence[Tuple[float, float, float]],
-                                                    Sequence[float], Sequence[float],
-                                                    Tuple[float, float, float],
-                                                    Tuple[float, float, float],
-                                                    float, float, int, int, int, int]:
+                             hits: pd.DataFrame)-> Tuple[Sequence[Tuple[float, float, float]],
+                                                   Sequence[Tuple[float, float, float]],
+                                                   Sequence[float], Sequence[float],
+                                                   Tuple[float, float, float],
+                                                   Tuple[float, float, float],
+                                                   float, float,
+                                                   Sequence[int], Sequence[int]]:
     """
     Finds the SiPM with maximum charge. Divide the SiPMs in two groups,
     separated by the plane perpendicular to the line connecting this SiPM
@@ -326,10 +327,6 @@ def reconstruct_coincidences(sns_response: pd.DataFrame,
     if not sel1 or not sel2:
         return [], [], [], [], None, None, None, None, None, None, None, None
 
-    ### TOF
-    min1, min_tof1 = find_first_time_of_sensors(tof_response, -sns1)
-    min2, min_tof2 = find_first_time_of_sensors(tof_response, -sns2)
-
     true_pos1, true_pos2, true_t1, true_t2, _, _ = find_first_interactions_in_active(particles, hits)
 
     if not len(true_pos1) or not len(true_pos2):
@@ -356,7 +353,7 @@ def reconstruct_coincidences(sns_response: pd.DataFrame,
         int_tof1 = min_tof2
         int_tof2 = min_tof1
 
-    return int_pos1, int_pos2, int_q1, int_q2, true_pos1, true_pos2, true_t1, true_t2, int_min1, int_min2, int_tof1, int_tof2
+    return int_pos1, int_pos2, int_q1, int_q2, true_pos1, true_pos2, true_t1, true_t2, sns1, sns2
 
 
 def select_coincidences(sns_response: pd.DataFrame, tof_response: pd.DataFrame,
@@ -386,7 +383,7 @@ def find_first_times_of_coincidences(sns_response: pd.DataFrame,
                                      hits: pd.DataFrame)-> Tuple[int, int, int, int]:
     """
     This function returns the IDs and times of the SiPMs that detect
-    the first photoelectrons.
+    the first photoelectrons, given the two sets of sensor IDs corresponding to the two interactions.
     DataSiPM_idx is assumed to be indexed on the sensor ids.
     """
     _, _, _, _, _, _, _, _, min1, min2, min_t1, min_t2 = reconstruct_coincidences(sns_response, tof_response, charge_range, DataSiPM_idx, particles, hits)

--- a/antea/reco/reco_functions.py
+++ b/antea/reco/reco_functions.py
@@ -343,13 +343,17 @@ def reconstruct_coincidences(sns_response: pd.DataFrame,
         int_pos2 = pos2
         int_q1   = q1
         int_q2   = q2
+        int_sns1 = sns1
+        int_sns2 = sns2
     else:
         int_pos1 = pos2
         int_pos2 = pos1
         int_q1   = q2
         int_q2   = q1
+        int_sns1 = sns2
+        int_sns2 = sns1
 
-    return int_pos1, int_pos2, int_q1, int_q2, true_pos1, true_pos2, true_t1, true_t2, sns1, sns2
+    return int_pos1, int_pos2, int_q1, int_q2, true_pos1, true_pos2, true_t1, true_t2, int_sns1, int_sns2
 
 
 def find_coincidence_timestamps(tof_response: pd.DataFrame,

--- a/antea/reco/reco_functions_test.py
+++ b/antea/reco/reco_functions_test.py
@@ -310,10 +310,10 @@ def test_change_unsigned_type_sipm(ANTEADATADIR):
 
         evt_parts = particles   [particles   .event_id == evt]
         evt_hits  = hits        [hits        .event_id == evt]
-        evt_tof   = tof_response[tof_response.event_id == evt]
 
-        pos1, pos2, q1, q2, *_ = rf.reconstruct_coincidences(evt_sns, evt_tof, charge_range,
-                                                             DataSiPM_idx, evt_parts, evt_hits)
+        pos1, pos2, q1, q2, *_ = rf.reconstruct_coincidences(evt_sns, charge_range,
+                                                             DataSiPM_idx, evt_parts,
+                                                             evt_hits)
         if len(pos1)!=0 and len(pos2)!=0:
             assert len(pos1) == len(q1)
             assert len(pos2) == len(q2)
@@ -348,9 +348,8 @@ def test_select_coincidences(ANTEADATADIR):
 
         sns = sel_df[sel_df.event_id == evt]
         if len(sns) == 0: continue
-        tof = tof_response[tof_response.event_id == evt]
 
-        pos1, pos2, q1, q2, true_pos1, true_pos2, true_t1, true_t2, *_ = rf.reconstruct_coincidences(sns, tof, charge_range, DataSiPM_idx, evt_parts, evt_hits)
+        pos1, pos2, q1, q2, true_pos1, true_pos2, true_t1, true_t2, *_ = rf.reconstruct_coincidences(sns, charge_range, DataSiPM_idx, evt_parts, evt_hits)
 
         if len(true_pos) == 2:
             scalar_prod1 = np.array([np.dot(true_pos1, p1) for p1 in pos1])
@@ -415,13 +414,8 @@ def test_only_gamma_hits_interaction():
                'time_bin': [0, 0], 'charge': [1100, 1200]}
    sns = pd.DataFrame(sns_data)
 
-   tof_data = {'event_id': [0, 0], 'sensor_id': [-2021, -3503],
-               'time_bin': [151, 200],
-               'charge': [1100, 1200]}
-   tof = pd.DataFrame(tof_data)
-
    charge_range = (1000, 1400)
-   pos1, pos2, q1, q2, true_pos1, true_pos2, _, _, _, _ = rf.reconstruct_coincidences(sns, tof, charge_range, DataSiPM_idx, particles, hits)
+   pos1, pos2, q1, q2, true_pos1, true_pos2, _, _, _, _ = rf.reconstruct_coincidences(sns, charge_range, DataSiPM_idx, particles, hits)
 
    assert len(pos1) != 0
    assert len(pos2) != 0

--- a/antea/reco/reco_functions_test.py
+++ b/antea/reco/reco_functions_test.py
@@ -312,12 +312,8 @@ def test_change_unsigned_type_sipm(ANTEADATADIR):
         evt_hits  = hits        [hits        .event_id == evt]
         evt_tof   = tof_response[tof_response.event_id == evt]
 
-        pos1, pos2, q1, q2, _, _, _, _, _, _ = rf.reconstruct_coincidences(evt_sns,
-                                                                           evt_tof,
-                                                                           charge_range,
-                                                                           DataSiPM_idx,
-                                                                           evt_parts,
-                                                                           evt_hits)
+        pos1, pos2, q1, q2, *_ = rf.reconstruct_coincidences(evt_sns, evt_tof, charge_range,
+                                                             DataSiPM_idx, evt_parts, evt_hits)
         if len(pos1)!=0 and len(pos2)!=0:
             assert len(pos1) == len(q1)
             assert len(pos2) == len(q2)
@@ -354,7 +350,7 @@ def test_select_coincidences(ANTEADATADIR):
         if len(sns) == 0: continue
         tof = tof_response[tof_response.event_id == evt]
 
-        pos1, pos2, q1, q2, true_pos1, true_pos2, true_t1, true_t2, _, _ = rf.reconstruct_coincidences(sns, tof, charge_range, DataSiPM_idx, evt_parts, evt_hits)
+        pos1, pos2, q1, q2, true_pos1, true_pos2, true_t1, true_t2, *_ = rf.reconstruct_coincidences(sns, tof, charge_range, DataSiPM_idx, evt_parts, evt_hits)
 
         if len(true_pos) == 2:
             scalar_prod1 = np.array([np.dot(true_pos1, p1) for p1 in pos1])

--- a/antea/reco/reco_functions_test.py
+++ b/antea/reco/reco_functions_test.py
@@ -312,12 +312,12 @@ def test_change_unsigned_type_sipm(ANTEADATADIR):
         evt_hits  = hits        [hits        .event_id == evt]
         evt_tof   = tof_response[tof_response.event_id == evt]
 
-        pos1, pos2, q1, q2, _, _, _, _, _, _, _, _ = rf.reconstruct_coincidences(evt_sns,
-                                                                                 evt_tof,
-                                                                                 charge_range,
-                                                                                 DataSiPM_idx,
-                                                                                 evt_parts,
-                                                                                 evt_hits)
+        pos1, pos2, q1, q2, _, _, _, _, _, _ = rf.reconstruct_coincidences(evt_sns,
+                                                                           evt_tof,
+                                                                           charge_range,
+                                                                           DataSiPM_idx,
+                                                                           evt_parts,
+                                                                           evt_hits)
         if len(pos1)!=0 and len(pos2)!=0:
             assert len(pos1) == len(q1)
             assert len(pos2) == len(q2)
@@ -354,7 +354,7 @@ def test_select_coincidences(ANTEADATADIR):
         if len(sns) == 0: continue
         tof = tof_response[tof_response.event_id == evt]
 
-        pos1, pos2, q1, q2, true_pos1, true_pos2, true_t1, true_t2 = rf.select_coincidences(sns, tof, charge_range, DataSiPM_idx, evt_parts, evt_hits)
+        pos1, pos2, q1, q2, true_pos1, true_pos2, true_t1, true_t2, _, _ = rf.reconstruct_coincidences(sns, tof, charge_range, DataSiPM_idx, evt_parts, evt_hits)
 
         if len(true_pos) == 2:
             scalar_prod1 = np.array([np.dot(true_pos1, p1) for p1 in pos1])
@@ -425,7 +425,7 @@ def test_only_gamma_hits_interaction():
    tof = pd.DataFrame(tof_data)
 
    charge_range = (1000, 1400)
-   pos1, pos2, q1, q2, true_pos1, true_pos2, _, _ = rf.select_coincidences(sns, tof, charge_range, DataSiPM_idx, particles, hits)
+   pos1, pos2, q1, q2, true_pos1, true_pos2, _, _, _, _ = rf.reconstruct_coincidences(sns, tof, charge_range, DataSiPM_idx, particles, hits)
 
    assert len(pos1) != 0
    assert len(pos2) != 0


### PR DESCRIPTION
This PR changes slightly the `reconstruct_coincidences` function in the following way. 
The information on the minimum timestamp and sensor of the two interactions is eliminated from the body of the function and from the return values. Instead, the function returns the two sets of sensor IDs corresponding to the two interactions. The reason of this change is that we need to calculate more than once the timestamp for the same event, using different charge thresholds. This way, this calculation can be done in a different function (`find_coincidence_timestamps`) and we don't need to call N times the full `reconstruct_coincidence` function.