### PR TITLE
Adds example sensitivity matrix

### DIFF
--- a/antea/testdata/petalo_fullbody_smatrix_180mm3.npz
+++ b/antea/testdata/petalo_fullbody_smatrix_180mm3.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b510f122c2dcc7a737e34da3e1af5b6ce67d8df55515baad6c819b96bac89ef3
+size 1728262

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,7 +21,7 @@ image can be performed in three different ways:
 2. :ref:`Fast simulation: NEXUS --> Fast MC --> Image Reco <fastmc>`
 3. :ref:`Fast-fast simulation: Fast-fast MC --> Image Reco <fastfastmc>`
 
-For image reconstruction, we use a :ref:`3D MLEM algorithm <imgreco>`.
+For image reconstruction, we use a 3D MLEM algorithm (`code <https://github.com/jerenner/tofpet3d>`_, `docs <https://tofpet3d.readthedocs.io>`_).
 
 Examples
 --------


### PR DESCRIPTION
An example sensitivity matrix is added to the testdata directory.

- A notebook showing how this matrix was generated is available here: https://github.com/nextic/ANTEANB/blob/master/sensitivity_matrix/sensitivity_matrix.ipynb
- The reconstruction example notebook (https://github.com/nextic/ANTEANB/blob/master/fastfastmc/petalo_reconstruction_fastfastmc_example.ipynb) has been updated to work with the reconstruction code now at https://github.com/jerenner/tofpet3d. A link to this repository and its documentation (https://tofpet3d.readthedocs.io) has been added to the ANTEA docs.