### PR TITLE
Error calculation on CRC and SNR

### DIFF
--- a/antea/image/fom_functions.py
+++ b/antea/image/fom_functions.py
@@ -9,13 +9,13 @@ a background.
 """
 
 
-def mean_std_dev_in_sphere2d(img2d : np.ndarray,
-                             sphere_r : float, r : float, phi : float,
-                             x_size : float, y_size : float,
-                             xbins : int, ybins : int) -> Tuple[float, float]:
+def mean_error_in_sphere2d(img2d : np.ndarray,
+                           sphere_r : float, r : float, phi : float,
+                           x_size : float, y_size : float,
+                           xbins : int, ybins : int) -> Tuple[float, float]:
     """
-    Calculates the average density in a circle of radius sphere_r,
-    centred in (r, phi).
+    Calculates the mean density in a circle of radius sphere_r,
+    centred in (r, phi) and the error on the mean.
     x_size, y_size: size of the image (in length unit).
     xbins, ybins: number of bins  in x and y.
 
@@ -48,16 +48,16 @@ def mean_std_dev_in_sphere2d(img2d : np.ndarray,
 
     circle = img2d[img_bins[:, 0], img_bins[:, 1]]
 
-    return np.average(circle), np.std(circle)
+    return np.average(circle), np.std(circle)/len(circle)
 
 
-def mean_std_dev_in_sphere3d(img3d : np.ndarray,
-                             sphere_r : float, r : float, phi : float,
-                             x_size : float, y_size : float, z_size : float,
-                             xbins : int, ybins : int, zbins : int) -> Tuple[float, float]:
+def mean_error_in_sphere3d(img3d : np.ndarray,
+                           sphere_r : float, r : float, phi : float,
+                           x_size : float, y_size : float, z_size : float,
+                           xbins : int, ybins : int, zbins : int) -> Tuple[float, float]:
     """
-    Calculates the average density in a sphere of radius sphere_r,
-    centred in (r, phi).
+    Calculates the mean density in a sphere of radius sphere_r,
+    centred in (r, phi) and the error on the mean.
     x_size, y_size, z_size: size of the image (in length unit).
     xbins, ybins, zbins: number of bins in x, y and z.
 
@@ -97,14 +97,14 @@ def mean_std_dev_in_sphere3d(img3d : np.ndarray,
 
     sphere = img3d[img_bins[:, 0], img_bins[:, 1], img_bins[:, 2]]
 
-    return np.average(sphere), np.std(sphere)
+    return np.average(sphere), np.std(sphere)/len(sphere)
 
 
 def average_mean_std_dev_in_bckg2d(img2d : np.ndarray,
                                    sphere_r : float, r : float,
                                    phi_start : float, phi_step : float,
                                    n_phi : int, x_size : float, y_size : float,
-                                   xbins : int, ybins: int) -> Tuple[float, float]:
+                                   xbins : int, ybins: int)-> Tuple[float, float, float, float]:
     """
     Calculates the average standard deviation of background
     taking the average of n_phi circles of radius sphere_r,
@@ -124,9 +124,9 @@ def average_mean_std_dev_in_bckg2d(img2d : np.ndarray,
 
     bckg_ave = std_bckg_ave = 0
     for i in range(n_phi):
-        bckg, std_bckg = mean_std_dev_in_sphere2d(img2d, sphere_r, r,
-                                               phi_start + i*phi_step, x_size,
-                                               y_size, xbins, ybins)
+        bckg, std_bckg = mean_error_in_sphere2d(img2d, sphere_r, r,
+                                                phi_start + i*phi_step, x_size,
+                                                y_size, xbins, ybins)
         bckg_ave += bckg
         std_bckg_ave += std_bckg
 
@@ -163,10 +163,10 @@ def average_mean_std_dev_in_bckg3d(img3d : np.ndarray,
 
     mean_bckg_ave = std_bckg_ave = 0
     for i in range(n_phi):
-        mean_bckg, std_bckg = mean_std_dev_in_sphere3d(img3d, sphere_r, r,
-                                                       phi_start + i*phi_step,
-                                                       x_size, y_size, z_size,
-                                                       xbins, ybins, zbins)
+        mean_bckg, std_bckg = mean_error_in_sphere3d(img3d, sphere_r, r,
+                                                     phi_start + i*phi_step,
+                                                     x_size, y_size, z_size,
+                                                     xbins, ybins, zbins)
         mean_bckg_ave += mean_bckg
         std_bckg_ave  += std_bckg
 
@@ -199,8 +199,8 @@ def crc_hot2d(img2d : np.ndarray, true_signal : float, true_bckg : float,
     :param ybins: number of bins of the image in the y axis.
     """
 
-    signal, _ = mean_std_dev_in_sphere2d(img2d, sig_sphere_r, r, phi,
-                                         x_size, y_size, xbins, ybins)
+    signal, _ = mean_error_in_sphere2d(img2d, sig_sphere_r, r, phi,
+                                       x_size, y_size, xbins, ybins)
     bckg, _   = average_mean_std_dev_in_bckg2d(img2d, bckg_sphere_r, r,
                                                phi0, phi_step, nphi,
                                                x_size, y_size,  xbins, ybins)
@@ -236,9 +236,9 @@ def crc_hot3d(img3d : np.ndarray, true_signal : float, true_bckg : float,
     :param zbins: number of bins of the image in the z axis.
     """
 
-    signal, _ = mean_std_dev_in_sphere3d(img3d, sig_sphere_r, r, phi,
-                                         x_size, y_size, z_size,
-                                         xbins, ybins, zbins)
+    signal, _ = mean_error_in_sphere3d(img3d, sig_sphere_r, r, phi,
+                                       x_size, y_size, z_size,
+                                       xbins, ybins, zbins)
     bckg, _   = average_mean_std_dev_in_bckg3d(img3d, bckg_sphere_r, r, phi0,
                                                phi_step, nphi, x_size, y_size,
                                                z_size, xbins, ybins, zbins)
@@ -270,8 +270,8 @@ def crc_cold2d(img2d : np.ndarray, sig_sphere_r : float, r : float, phi : float,
     :param ybins: number of bins of the image in the y axis.
     """
 
-    signal, _ = mean_std_dev_in_sphere2d(img2d, sig_sphere_r, r, phi,
-                                         x_size, y_size, xbins, ybins)
+    signal, _ = mean_error_in_sphere2d(img2d, sig_sphere_r, r, phi,
+                                       x_size, y_size, xbins, ybins)
     bckg, _   = average_mean_std_dev_in_bckg2d(img2d, bckg_sphere_r, r, phi0,
                                                phi_step, nphi, x_size, y_size,
                                                xbins, ybins)
@@ -302,9 +302,9 @@ def crc_cold3d(img3d : np.ndarray, sig_sphere_r : float, r : float, phi : float,
     :param zbins: number of bins of the image in the z axis.
     """
 
-    signal, _ = mean_std_dev_in_sphere3d(img3d, sig_sphere_r, r, phi,
-                                         x_size, y_size, z_size,
-                                         xbins, ybins, zbins)
+    signal, _ = mean_error_in_sphere3d(img3d, sig_sphere_r, r, phi,
+                                       x_size, y_size, z_size,
+                                       xbins, ybins, zbins)
     bckg, _   = average_mean_std_dev_in_bckg3d(img3d, bckg_sphere_r, r, phi0,
                                                phi_step, nphi, x_size, y_size,
                                                z_size, xbins, ybins, zbins)
@@ -334,8 +334,8 @@ def snr2d(img2d : np.ndarray,
     :param ybins: number of bins of the image in the y axis.
     """
 
-    signal, _    = mean_std_dev_in_sphere2d(img2d, sig_sphere_r, r, phi,
-                                            x_size, y_size, xbins, ybins)
+    signal, _ = mean_error_in_sphere2d(img2d, sig_sphere_r, r, phi,
+                                       x_size, y_size, xbins, ybins)
     bckg, std_dev_bckg = average_mean_std_dev_in_bckg2d(img2d, bckg_sphere_r, r,
                                                         phi0, phi_step, nphi,
                                                         x_size, y_size,  xbins,
@@ -368,9 +368,9 @@ def snr3d(img3d : np.ndarray,
     :param zbins: number of bins of the image in the z axis.
     """
 
-    signal, _    = mean_std_dev_in_sphere3d(img3d, sig_sphere_r, r, phi,
-                                            x_size, y_size, z_size,
-                                            xbins, ybins, zbins)
+    signal, _ = mean_error_in_sphere3d(img3d, sig_sphere_r, r, phi,
+                                       x_size, y_size, z_size,
+                                       xbins, ybins, zbins)
     bckg, std_dev_bckg = average_mean_std_dev_in_bckg3d(img3d, bckg_sphere_r, r,
                                                         phi0, phi_step, nphi,
                                                         x_size, y_size, z_size,

--- a/antea/image/fom_functions.py
+++ b/antea/image/fom_functions.py
@@ -176,9 +176,10 @@ def average_mean_error_in_bckg3d(img3d : np.ndarray,
 def crc_hot2d(img2d : np.ndarray, true_signal : float, true_bckg : float,
               sig_sphere_r : float, r : float, phi : float,
               bckg_sphere_r : float, phi0 : float, phi_step : float, nphi : int,
-              x_size : float, y_size : float, xbins : int, ybins : int) -> float:
+              x_size : float, y_size : float,
+              xbins : int, ybins : int) -> Tuple[float, float]:
     """
-    Calculates the contrast_recovery_coefficent of hot circle.
+    Calculates the contrast_recovery_coefficent of hot circle and its error.
 
     :param img2d: 2D np.array with the image.
     :param true_signal: maximum value of original image pixels.
@@ -196,24 +197,25 @@ def crc_hot2d(img2d : np.ndarray, true_signal : float, true_bckg : float,
     :param ybins: number of bins of the image in the y axis.
     """
 
-    signal, _ = mean_error_in_sphere2d(img2d, sig_sphere_r, r, phi,
-                                       x_size, y_size, xbins, ybins)
-    bckg, _, _, _   = average_mean_error_in_bckg2d(img2d, bckg_sphere_r, r,
-                                                   phi0, phi_step, nphi,
-                                                   x_size, y_size,  xbins, ybins)
+    sig, err_sig = mean_error_in_sphere2d(img2d, sig_sphere_r, r, phi,
+                                          x_size, y_size, xbins, ybins)
+    mean_bckg, err_mean_bckg, _, _ = average_mean_error_in_bckg2d(img2d, bckg_sphere_r, r, phi0, phi_step, nphi, x_size, y_size,  xbins, ybins)
 
     alpha = true_signal / true_bckg
 
-    return (signal/bckg - 1)/(alpha - 1)
+    crc = (sig/mean_bckg - 1)/(alpha - 1)
+    err = np.sqrt((err_sig/mean_bckg)**2 + (err_mean_bckg*sig/mean_bckg**2)**2)/(alpha - 1)
+
+    return crc, err
 
 
 def crc_hot3d(img3d : np.ndarray, true_signal : float, true_bckg : float,
               sig_sphere_r : float, r : float, phi : float,
               bckg_sphere_r : float, phi0 : float, phi_step : float, nphi : int,
               x_size : float, y_size : float, z_size : float,
-              xbins : int, ybins : int, zbins : int):
+              xbins : int, ybins : int, zbins : int) -> Tuple[float, float]:
     """
-    Calculates the contrast_recovery_coefficent of hot sphere.
+    Calculates the contrast_recovery_coefficent of hot sphere and its error.
 
     :param img3d: 3D np.array with the image.
     :param true_signal: maximum value of original image pixels.
@@ -233,25 +235,26 @@ def crc_hot3d(img3d : np.ndarray, true_signal : float, true_bckg : float,
     :param zbins: number of bins of the image in the z axis.
     """
 
-    signal, _ = mean_error_in_sphere3d(img3d, sig_sphere_r, r, phi,
-                                       x_size, y_size, z_size,
-                                       xbins, ybins, zbins)
-    bckg, _, _, _   = average_mean_error_in_bckg3d(img3d, bckg_sphere_r, r, phi0,
-                                                   phi_step, nphi, x_size, y_size,
-                                                   z_size, xbins, ybins, zbins)
+    sig, err_sig = mean_error_in_sphere3d(img3d, sig_sphere_r, r, phi,
+                                          x_size, y_size, z_size,
+                                          xbins, ybins, zbins)
+    mean_bckg, err_mean_bckg, _, _ = average_mean_error_in_bckg3d(img3d, bckg_sphere_r, r, phi0, phi_step, nphi, x_size, y_size, z_size, xbins, ybins, zbins)
 
     alpha = true_signal / true_bckg
 
-    return (signal/bckg - 1)/(alpha - 1)
+    crc = (sig/mean_bckg - 1)/(alpha - 1)
+    err = np.sqrt((err_sig/mean_bckg)**2 + (err_mean_bckg*sig/mean_bckg**2)**2)/(alpha - 1)
+
+    return crc, err
 
 
 
 def crc_cold2d(img2d : np.ndarray, sig_sphere_r : float, r : float, phi : float,
                bckg_sphere_r : float, phi0 : float, phi_step : float,
                nphi : int, x_size : float, y_size : float, xbins : int,
-               ybins : int) -> float:
+               ybins : int) -> Tuple[float, float]:
     """
-    Calculates the contrast_recovery_coefficent of a cold circle.
+    Calculates the contrast_recovery_coefficent of a cold circle and its error.
 
     :param img2d: 2D np.array with the image.
     :param sig_sphere_r: radius of the sphere of signal.
@@ -267,21 +270,25 @@ def crc_cold2d(img2d : np.ndarray, sig_sphere_r : float, r : float, phi : float,
     :param ybins: number of bins of the image in the y axis.
     """
 
-    signal, _ = mean_error_in_sphere2d(img2d, sig_sphere_r, r, phi,
-                                       x_size, y_size, xbins, ybins)
-    bckg, _, _, _   = average_mean_error_in_bckg2d(img2d, bckg_sphere_r, r, phi0,
-                                                   phi_step, nphi, x_size, y_size,
-                                                   xbins, ybins)
+    sig, err_sig = mean_error_in_sphere2d(img2d, sig_sphere_r, r, phi,
+                                          x_size, y_size, xbins, ybins)
+    mean_bckg, err_mean_bckg, _, _ = average_mean_error_in_bckg2d(img2d, bckg_sphere_r,
+                                                                  r, phi0, phi_step,
+                                                                  nphi, x_size, y_size,
+                                                                  xbins, ybins)
 
-    return 1 - signal / bckg
+    crc = 1 - sig / mean_bckg
+    err = np.sqrt((err_sig/mean_bckg)**2 + (err_mean_bckg*sig/mean_bckg**2)**2)
+
+    return crc, err
 
 
 def crc_cold3d(img3d : np.ndarray, sig_sphere_r : float, r : float, phi : float,
                bckg_sphere_r : float, phi0 : float, phi_step : float,
                nphi : int, x_size : float, y_size : float, z_size : float,
-               xbins : int, ybins : int, zbins : int) -> float:
+               xbins : int, ybins : int, zbins : int) -> Tuple[float, float]:
     """
-    Calculates the contrast_recovery_coefficent of a cold sphere.
+    Calculates the contrast_recovery_coefficent of a cold sphere and its error.
 
     :param img3d: 3D np.array with the image.
     :param sig_sphere_r: radius of the sphere of signal.
@@ -299,23 +306,27 @@ def crc_cold3d(img3d : np.ndarray, sig_sphere_r : float, r : float, phi : float,
     :param zbins: number of bins of the image in the z axis.
     """
 
-    signal, _ = mean_error_in_sphere3d(img3d, sig_sphere_r, r, phi,
-                                       x_size, y_size, z_size,
-                                       xbins, ybins, zbins)
-    bckg, _, _, _   = average_mean_error_in_bckg3d(img3d, bckg_sphere_r, r, phi0,
-                                                   phi_step, nphi, x_size, y_size,
-                                                   z_size, xbins, ybins, zbins)
+    sig, err_sig = mean_error_in_sphere3d(img3d, sig_sphere_r, r, phi,
+                                          x_size, y_size, z_size,
+                                          xbins, ybins, zbins)
+    mean_bckg, err_mean_bckg, _, _ = average_mean_error_in_bckg3d(img3d, bckg_sphere_r,
+                                                                  r, phi0, phi_step,
+                                                                  nphi, x_size, y_size,
+                                                                  z_size, xbins, ybins,
+                                                                  zbins)
 
-    return 1 - signal / bckg
+    crc = 1 - sig / mean_bckg
+    err = np.sqrt((err_sig/mean_bckg)**2 + (err_mean_bckg*sig/mean_bckg**2)**2)
+
+    return crc, err
 
 
-def snr2d(img2d : np.ndarray,
-          sig_sphere_r : float, r : float, phi : float,
+def snr2d(img2d : np.ndarray, sig_sphere_r : float, r : float, phi : float,
           bckg_sphere_r : float, phi0 : float, phi_step : float, nphi : int,
           x_size : float, y_size : float,
-          xbins : int, ybins : int) -> float:
+          xbins : int, ybins : int) -> Tuple[float, float]:
     """
-    Calculates the signal to noise ratio of a 2D image.
+    Calculates the signal to noise ratio of a 2D image and its error.
 
     :param img2d: 2D np.array with the image.
     :param sig_sphere_r: radius of the sphere of signal.
@@ -331,23 +342,22 @@ def snr2d(img2d : np.ndarray,
     :param ybins: number of bins of the image in the y axis.
     """
 
-    signal, _ = mean_error_in_sphere2d(img2d, sig_sphere_r, r, phi,
-                                       x_size, y_size, xbins, ybins)
-    bckg, err_bckg, _, _ = average_mean_error_in_bckg2d(img2d, bckg_sphere_r, r,
-                                                        phi0, phi_step, nphi,
-                                                        x_size, y_size,  xbins,
-                                                        ybins)
+    sig, err_sig = mean_error_in_sphere2d(img2d, sig_sphere_r, r, phi,
+                                          x_size, y_size, xbins, ybins)
+    mean_bckg, err_mean_bckg, mean_err_bckg, err_err_bckg = average_mean_error_in_bckg2d(img2d, bckg_sphere_r, r, phi0, phi_step, nphi, x_size, y_size,  xbins, ybins)
 
-    return (signal - bckg) / err_bckg
+    snr = (sig - mean_bckg) / mean_err_bckg
+    err = np.sqrt((err_sig/mean_err_bckg)**2 + (err_mean_bckg/mean_err_bckg)**2 + ((sig-mean_bckg)/mean_err_bckg**2*err_err_bckg)**2)
+
+    return snr, err
 
 
-def snr3d(img3d : np.ndarray,
-          sig_sphere_r : float, r : float, phi : float,
+def snr3d(img3d : np.ndarray, sig_sphere_r : float, r : float, phi : float,
           bckg_sphere_r : float, phi0 : float, phi_step : float, nphi : int,
           x_size : float, y_size : float, z_size : float,
-          xbins : int, ybins : int, zbins : int) -> float:
+          xbins : int, ybins : int, zbins : int) -> Tuple[float, float]:
     """
-    Calculates the signal to noise ratio of a 3D image.
+    Calculates the signal to noise ratio of a 3D image and its error.
 
     :param img3d: 3D np.array with the image.
     :param sig_sphere_r: radius of the sphere of signal.
@@ -365,12 +375,12 @@ def snr3d(img3d : np.ndarray,
     :param zbins: number of bins of the image in the z axis.
     """
 
-    signal, _ = mean_error_in_sphere3d(img3d, sig_sphere_r, r, phi,
-                                       x_size, y_size, z_size,
-                                       xbins, ybins, zbins)
-    bckg, err_bckg, _, _ = average_mean_error_in_bckg3d(img3d, bckg_sphere_r, r,
-                                                        phi0, phi_step, nphi,
-                                                        x_size, y_size, z_size,
-                                                        xbins, ybins, zbins)
+    sig, err_sig = mean_error_in_sphere3d(img3d, sig_sphere_r, r, phi,
+                                          x_size, y_size, z_size,
+                                          xbins, ybins, zbins)
+    mean_bckg, err_mean_bckg, mean_err_bckg, err_err_bckg = average_mean_error_in_bckg3d(img3d, bckg_sphere_r, r, phi0, phi_step, nphi, x_size, y_size, z_size, xbins, ybins, zbins)
 
-    return (signal - bckg) / err_bckg
+    snr = (sig - mean_bckg) / mean_err_bckg
+    err = np.sqrt((err_sig/mean_err_bckg)**2 + (err_mean_bckg/mean_err_bckg)**2 + ((sig-mean_bckg)/mean_err_bckg**2*err_err_bckg)**2)
+
+    return snr, err

--- a/antea/image/fom_functions.py
+++ b/antea/image/fom_functions.py
@@ -48,7 +48,7 @@ def mean_error_in_sphere2d(img2d : np.ndarray,
 
     circle = img2d[img_bins[:, 0], img_bins[:, 1]]
 
-    return np.average(circle), np.std(circle)/len(circle)
+    return np.average(circle), np.std(circle)/np.sqrt(len(circle))
 
 
 def mean_error_in_sphere3d(img3d : np.ndarray,
@@ -97,7 +97,7 @@ def mean_error_in_sphere3d(img3d : np.ndarray,
 
     sphere = img3d[img_bins[:, 0], img_bins[:, 1], img_bins[:, 2]]
 
-    return np.average(sphere), np.std(sphere)/len(sphere)
+    return np.average(sphere), np.std(sphere)/np.sqrt(len(sphere))
 
 
 def average_mean_error_in_bckg2d(img2d : np.ndarray,
@@ -132,7 +132,7 @@ def average_mean_error_in_bckg2d(img2d : np.ndarray,
         mean_bckgs.append(mean_bckg)
         err_bckgs.append(err_bckg)
 
-    return np.average(mean_bckgs), np.std(mean_bckgs)/n_phi, np.average(err_bckgs), np.std(err_bckgs)/n_phi
+    return np.average(mean_bckgs), np.std(mean_bckgs)/np.sqrt(n_phi), np.average(err_bckgs), np.std(err_bckgs)/np.sqrt(n_phi)
 
 
 def average_mean_error_in_bckg3d(img3d : np.ndarray,
@@ -170,7 +170,7 @@ def average_mean_error_in_bckg3d(img3d : np.ndarray,
         mean_bckgs.append(mean_bckg)
         err_bckgs.append(err_bckg)
 
-    return np.average(mean_bckgs), np.std(mean_bckgs)/n_phi, np.average(err_bckgs), np.std(err_bckgs)/n_phi
+    return np.average(mean_bckgs), np.std(mean_bckgs)/np.sqrt(n_phi), np.average(err_bckgs), np.std(err_bckgs)/np.sqrt(n_phi)
 
 
 def crc_hot2d(img2d : np.ndarray, true_signal : float, true_bckg : float,

--- a/antea/image/fom_functions_test.py
+++ b/antea/image/fom_functions_test.py
@@ -42,20 +42,20 @@ def test_true_signal_crc_is_close_to_one(phantom_true_img):
     img_slice = np.sum(phantom_true_img[:,:,89:90], axis=2)
 
     for i in range(0, len(hot_phi)):
-        crc = fomf.crc_hot2d(img_slice, sig_intensity, bckg_intensity,
-                             hot_sphere_r[i], r, hot_phi[i],
-                             bckg_sphere_r, phi0, phi_step, nphi,
-                             x_size, y_size, xbins, ybins)
+        crc, _ = fomf.crc_hot2d(img_slice, sig_intensity, bckg_intensity,
+                                hot_sphere_r[i], r, hot_phi[i],
+                                bckg_sphere_r, phi0, phi_step, nphi,
+                                x_size, y_size, xbins, ybins)
 
         assert np.isclose(crc, 1, rtol=5e-02, atol=5e-02)
 
     ### take the 3d image
     for i in range(0, len(hot_phi)):
-        crc = fomf.crc_hot3d(phantom_true_img, sig_intensity, bckg_intensity,
-                             hot_sphere_r[i], r, hot_phi[i],
-                             bckg_sphere_r, phi0, phi_step, nphi,
-                             x_size, y_size, z_size,
-                             xbins, ybins, zbins)
+        crc, _ = fomf.crc_hot3d(phantom_true_img, sig_intensity, bckg_intensity,
+                                hot_sphere_r[i], r, hot_phi[i],
+                                bckg_sphere_r, phi0, phi_step, nphi,
+                                x_size, y_size, z_size,
+                                xbins, ybins, zbins)
 
         assert np.isclose(crc, 1, rtol=5e-02, atol=5e-02)
 
@@ -66,19 +66,19 @@ def test_true_background_crc_is_close_to_zero(phantom_true_img):
     img_slice = np.sum(phantom_true_img[:,:,89:90], axis=2)
 
     for i in range(0, len(cold_phi)):
-        crc = fomf.crc_cold2d(img_slice, cold_sphere_r[i],
-                              r, cold_phi[i], bckg_sphere_r,
-                              phi0, phi_step, nphi,
-                              x_size, y_size, xbins, ybins)
+        crc, _ = fomf.crc_cold2d(img_slice, cold_sphere_r[i],
+                                 r, cold_phi[i], bckg_sphere_r,
+                                 phi0, phi_step, nphi,
+                                 x_size, y_size, xbins, ybins)
 
         assert np.isclose(crc, 1, rtol=1e-02, atol=1e-02)
 
     ### take the 3d image
     for i in range(0, len(cold_phi)):
-        crc = fomf.crc_cold3d(phantom_true_img, cold_sphere_r[i],
-                              r, cold_phi[i], bckg_sphere_r,
-                              phi0, phi_step, nphi,
-                              x_size, y_size, z_size, xbins, ybins, zbins)
+        crc, _ = fomf.crc_cold3d(phantom_true_img, cold_sphere_r[i],
+                                 r, cold_phi[i], bckg_sphere_r,
+                                 phi0, phi_step, nphi,
+                                 x_size, y_size, z_size, xbins, ybins, zbins)
 
         assert np.isclose(crc, 1, rtol=1e-02, atol=1e-02)
 
@@ -89,16 +89,16 @@ def test_signal_to_noise_ratio_is_infinite(phantom_true_img):
     img_slice = np.sum(phantom_true_img[:,:,89:90], axis=2)
 
     for i in range(0, len(hot_phi)):
-        snr = fomf.snr2d(img_slice, hot_sphere_r[i], r, hot_phi[i],
-                         bckg_sphere_r, phi0, phi_step, nphi,
-                         x_size, y_size, xbins, ybins)
+        snr, _ = fomf.snr2d(img_slice, hot_sphere_r[i], r, hot_phi[i],
+                            bckg_sphere_r, phi0, phi_step, nphi,
+                            x_size, y_size, xbins, ybins)
 
         assert math.isinf(snr)
 
     ### take the 3d image
     for i in range(0, len(cold_phi)):
-        snr = fomf.snr3d(phantom_true_img, hot_sphere_r[i], r, hot_phi[i],
-                         bckg_sphere_r, phi0, phi_step, nphi,
-                         x_size, y_size, z_size, xbins, ybins, zbins)
+        snr, _ = fomf.snr3d(phantom_true_img, hot_sphere_r[i], r, hot_phi[i],
+                            bckg_sphere_r, phi0, phi_step, nphi,
+                            x_size, y_size, z_size, xbins, ybins, zbins)
 
         assert math.isinf(snr)


### PR DESCRIPTION
This PR adds the calculation of errors to the contrast recovery coefficient and the signal to noise ratio functions. We use the error on the mean for all the quantities under consideration.