### PR TITLE
Load sensor positions

### DIFF
--- a/antea/io/mc_io.py
+++ b/antea/io/mc_io.py
@@ -97,6 +97,13 @@ def load_configuration(file_name: str) -> pd.DataFrame:
     return conf
 
 
+def load_sns_positions(file_name: str) -> pd.DataFrame:
+
+    sns_positions = pd.read_hdf(file_name, 'MC/sns_positions')
+
+    return sns_positions
+
+
 def read_sensor_bin_width_from_conf(filename, tof=False):
     """
     Return the time bin width (either TOF or no TOF) with units.


### PR DESCRIPTION
`sns_positions` is one of the tables in the MC files, and I think the new defined function is very useful when the position of the sensors for one geometry is not in the database and we need to extract it from the MC file.