### PR TITLE
Eliminate unused import

### DIFF
--- a/antea/reco/reco_functions.py
+++ b/antea/reco/reco_functions.py
@@ -1,8 +1,6 @@
 import numpy  as np
 import pandas as pd
 
-from . mctrue_functions import find_hits_of_given_particles
-
 from antea.core.exceptions import WaveformEmptyTable
 
 from typing import Sequence, Tuple


### PR DESCRIPTION
I have realized that the function `find_hits_of_given_particles` from `mctrue_functions` is imported in `reco_functions` but not used. This PR removes that import.